### PR TITLE
Added Pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@ streams/
 # Secrets
 *.env
 
+# Development test files
+test.html
+test.py
+test.sqlite3
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/constants.py
+++ b/constants.py
@@ -12,17 +12,20 @@ from zoneinfo import ZoneInfo
 from dotenv import load_dotenv
 
 
-def datetime_now_local() -> str:
+def datetime_now_local() -> datetime.datetime:
     """
     Returns a string of the current datetime in the current timezone that is safe to be used in
      Windows file names.
     """
-    return (
-        datetime.datetime.now(ZoneInfo("Europe/Amsterdam"))
-        .replace(microsecond=0)
-        .isoformat()
-        .replace(":", ".")
-    )
+    return datetime.datetime.now(ZoneInfo("Europe/Amsterdam"))
+
+
+def datetime_now_local_str() -> str:
+    """
+    Returns a string of the current datetime in the current timezone that is safe to be used in
+     Windows file names.
+    """
+    return datetime_now_local().replace(microsecond=0).isoformat().replace(":", ".")
 
 
 MAIN_FOLDER = Path(__file__).parent

--- a/constants.py
+++ b/constants.py
@@ -3,11 +3,27 @@ Functions as a central location to load constants from such as paths to director
  values that are globally configured, and secrets loaded from environment.
 """
 
+import datetime
 import os
 import platform
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 from dotenv import load_dotenv
+
+
+def datetime_now_local() -> str:
+    """
+    Returns a string of the current datetime in the current timezone that is safe to be used in
+     Windows file names.
+    """
+    return (
+        datetime.datetime.now(ZoneInfo("Europe/Amsterdam"))
+        .replace(microsecond=0)
+        .isoformat()
+        .replace(":", ".")
+    )
+
 
 MAIN_FOLDER = Path(__file__).parent
 load_dotenv(MAIN_FOLDER / ".env")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+flask
+matplotlib
+requests
+uuid6

--- a/run_temperature_api.py
+++ b/run_temperature_api.py
@@ -1,4 +1,10 @@
+"""
+Start the Temperature API Flask app.
+"""
+
 from temperature_api import app
+from temperature_api.api.pagination import delete_expired
 
 if __name__ == "__main__":
+    delete_expired()
     app.run(host="0.0.0.0", port=4001, debug=True)

--- a/temperature_api/api/pagination.py
+++ b/temperature_api/api/pagination.py
@@ -1,19 +1,41 @@
+"""
+See class docstring.
+"""
+
+import csv
 import datetime
 import uuid
 
-from constants import DATA_DIR
+from constants import DATA_DIR, datetime_now_local
 
 
 class Pagination:
-    def __init__(self, stream, start_datetime, end_datetime):
-        self.file_paths = self.get_file_paths(stream, start_datetime, end_datetime)
-        self.id = uuid.uuid4()
-        self.expires = 
+    """
+    Enables pagination for the temperature API.
+    """
 
-    def get_file_paths(stream, start_datetime, end_datetime):
+    def __init__(self, stream, start_datetime, end_datetime):
+        self.stream = stream
+        self.start_datetime = start_datetime
+        self.end_datetime = end_datetime
+        self.all_file_paths = self.get_all_file_paths(
+            stream, start_datetime, end_datetime
+        )
+        self.file_paths_processed = []
+        self.id = uuid.uuid4()
+        self.expires = datetime_now_local() + datetime.timedelta(hours=1)
+        self.current_page = 0
+        self.determined_pages = {}
+        self.minimum_items_per_page = 10_000
+
+    def get_all_file_paths(self, stream, start_datetime, end_datetime):
+        """
+        Get all files for the selected stream that are timestamped in between the start and end
+         datetimes.
+        """
         file_paths = []
         for file_path in (DATA_DIR / stream).glob("*.csv"):
-            file_datetime = datetime.fromisoformat(
+            file_datetime = datetime.datetime.fromisoformat(
                 file_path.name.removesuffix(file_path.suffix)
                 .removeprefix(f"{stream}_")
                 .replace(".", ":")
@@ -25,3 +47,49 @@ class Pagination:
             ):
                 file_paths.append(file_path)
         return file_paths
+
+    def get_file_paths_for_page(self, requested_page=0):
+        """
+        Assigns files to pages based on the minimum number of items per page set and the number of
+         lines per files.
+        """
+        for page_nr in range(requested_page + 1):
+            if page_nr in self.determined_pages:
+                continue
+            items_selected = 0
+            self.determined_pages[page_nr] = []
+            for file_path in (
+                path
+                for path in self.all_file_paths
+                if path not in self.file_paths_processed
+            ):
+                # Subtracting one for the header.
+                items_selected += open(file_path, encoding="utf-8").readlines() - 1
+                self.determined_pages[page_nr].append(file_path)
+                self.file_paths_processed.append(file_path)
+                if items_selected >= self.minimum_items_per_page:
+                    break
+        return self.determined_pages[requested_page]
+
+    def get_data(self, requested_page=0):
+        """
+        Returns a dictionary of lists containing all the present raw data for the paginated stream
+        between the start and end datetimes, inclusive, for the requested page.
+        If no page is specified, the first one is returned.
+        """
+        file_paths = self.get_file_paths_for_page(requested_page)
+        data = {}
+        for file_path in file_paths:
+            with open(file_path, encoding="utf-8") as file:
+                reader = csv.DictReader(file)
+                for row in reader:
+                    if (
+                        self.start_datetime
+                        <= datetime.datetime.fromisoformat(row["Datetime"])
+                        <= self.end_datetime
+                    ):
+                        for key, value in row.items():
+                            if key not in data:
+                                data[key] = []
+                            data[key].append(value)
+        return data

--- a/temperature_api/api/pagination.py
+++ b/temperature_api/api/pagination.py
@@ -1,0 +1,27 @@
+import datetime
+import uuid
+
+from constants import DATA_DIR
+
+
+class Pagination:
+    def __init__(self, stream, start_datetime, end_datetime):
+        self.file_paths = self.get_file_paths(stream, start_datetime, end_datetime)
+        self.id = uuid.uuid4()
+        self.expires = 
+
+    def get_file_paths(stream, start_datetime, end_datetime):
+        file_paths = []
+        for file_path in (DATA_DIR / stream).glob("*.csv"):
+            file_datetime = datetime.fromisoformat(
+                file_path.name.removesuffix(file_path.suffix)
+                .removeprefix(f"{stream}_")
+                .replace(".", ":")
+            )
+            if (
+                start_datetime.replace(minute=0, second=0, microsecond=0)
+                <= file_datetime
+                <= end_datetime.replace(minute=0, second=0, microsecond=0)
+            ):
+                file_paths.append(file_path)
+        return file_paths

--- a/temperature_api/api/pagination.py
+++ b/temperature_api/api/pagination.py
@@ -4,9 +4,18 @@ See class docstring.
 
 import csv
 import datetime
-import uuid
+import json
+import sqlite3
 
-from constants import DATA_DIR, datetime_now_local
+import uuid6
+
+from constants import APP_DATA_DIR, DATA_DIR, datetime_now_local
+
+PAGINATION_DATABASE = APP_DATA_DIR / "pagination.sqlite3"
+
+if not PAGINATION_DATABASE.exists():
+    CONNECTION = sqlite3.connect(PAGINATION_DATABASE)
+    CONNECTION.close()
 
 
 class Pagination:
@@ -14,19 +23,96 @@ class Pagination:
     Enables pagination for the temperature API.
     """
 
-    def __init__(self, stream, start_datetime, end_datetime):
+    def __init__(
+        self,
+        stream=None,
+        start_datetime=None,
+        end_datetime=None,
+        minimum_items_per_page=10_000,
+        serialized_pagination=None,
+    ):
+        if (
+            stream is None
+            and start_datetime is None
+            and end_datetime is None
+            and serialized_pagination is not None
+        ):
+            self.deserialize(serialized_pagination)
+            return
+        self.id = uuid6.uuid7()
+        self.expires = datetime_now_local() + datetime.timedelta(hours=1)
+        self.data = [
+            {"path": path, "page": None}
+            for path in self.get_all_file_paths(stream, start_datetime, end_datetime)
+        ]
         self.stream = stream
         self.start_datetime = start_datetime
         self.end_datetime = end_datetime
-        self.all_file_paths = self.get_all_file_paths(
-            stream, start_datetime, end_datetime
+        self.minimum_items_per_page = minimum_items_per_page
+
+    def serialize(self):
+        """
+        Returns a serialized version of the object in the form of a JSON string.
+        """
+        return json.dumps(
+            {
+                "id": self.id,
+                "expires": self.expires.isoformat(),
+                "data": [
+                    {"path": item["path"].relative_to(DATA_DIR), "page": item["page"]}
+                    for item in self.data
+                ],
+                "metadata": {
+                    "stream": self.stream,
+                    "startDatetime": self.start_datetime.isoformat(),
+                    "endDatetime": self.end_datetime.isoformat(),
+                    "minumumItemsPerPage": self.minimum_items_per_page,
+                },
+            }
         )
-        self.file_paths_processed = []
-        self.id = uuid.uuid4()
-        self.expires = datetime_now_local() + datetime.timedelta(hours=1)
-        self.current_page = 0
-        self.determined_pages = {}
-        self.minimum_items_per_page = 10_000
+
+    def deserialize(self, serialized_pagination: str):
+        """
+        Deserializes a pagination object from a JSON string.
+        """
+        dictionary_ = json.loads(serialized_pagination)
+        self.id = dictionary_["id"]
+        self.expires = dictionary_["expires"]
+        self.data = [
+            {"path": DATA_DIR / item["path"], "page": item["page"]}
+            for item in dictionary_
+        ]
+        self.stream = dictionary_["metadata"]["stream"]
+        self.start_datetime = dictionary_["metadata"]["startDatetime"]
+        self.end_datetime = dictionary_["metadata"]["endDatetime"]
+        self.minimum_items_per_page = dictionary_["metadata"]["minimumItemsPerPage"]
+
+    def dump(self):
+        """
+        Dump a pagination object to the pagination database.
+        INSERT if it doesn't yet exist.
+        UPDATE if it does.
+        """
+        with sqlite3.connect(
+            PAGINATION_DATABASE
+        ) as connection, sqlite3.Row as connection.row_factory, connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT * FROM [pagination] WHERE [paginationId] = ?",
+                self.id,
+            )
+            if cursor.fetchone():
+                cursor.execute(
+                    "UPDATE [pagination] SET [pagination] = ? WHERE [paginationId] = ?",
+                    self.serialize(),
+                    self.id,
+                )
+            else:
+                cursor.execute(
+                    "INSERT INTO [pagination] ([paginationId], [pagination]) VALUES (?, ?)",
+                    self.id,
+                    self.serialize(),
+                )
+            connection.commit()
 
     def get_all_file_paths(self, stream, start_datetime, end_datetime):
         """
@@ -53,23 +139,20 @@ class Pagination:
         Assigns files to pages based on the minimum number of items per page set and the number of
          lines per files.
         """
+        # TODO: edge-case, higher page number than required pages
         for page_nr in range(requested_page + 1):
-            if page_nr in self.determined_pages:
+            if page_nr in (item["page"] for item in self.data):
                 continue
             items_selected = 0
-            self.determined_pages[page_nr] = []
-            for file_path in (
-                path
-                for path in self.all_file_paths
-                if path not in self.file_paths_processed
-            ):
+            for item in self.data:
+                if item["page"] is not None:
+                    continue
                 # Subtracting one for the header.
-                items_selected += open(file_path, encoding="utf-8").readlines() - 1
-                self.determined_pages[page_nr].append(file_path)
-                self.file_paths_processed.append(file_path)
+                items_selected += open(item["path"], encoding="utf-8").readlines() - 1
+                item["page"] = page_nr
                 if items_selected >= self.minimum_items_per_page:
                     break
-        return self.determined_pages[requested_page]
+        return [item["path"] for item in self.data if item["page"] == requested_page]
 
     def get_data(self, requested_page=0):
         """
@@ -77,6 +160,22 @@ class Pagination:
         between the start and end datetimes, inclusive, for the requested page.
         If no page is specified, the first one is returned.
         """
+        if self.expires > datetime_now_local():
+            example_data = json.dumps(
+                {
+                    "stream": self.stream,
+                    "startDatetime": self.start_datetime.isoformat(),
+                    "endDatetime": self.end_datetime.isoformat(),
+                    "minimumItemsPerPage": self.minimum_items_per_page,
+                },
+                indent=4,
+            )
+            return {
+                "message": f"This pagination ID has expired since {self.expires.isoformat()}. \
+Please send a fresh request. \
+Based on the data for this pagination ID that POST request would use the data: {example_data}"
+            }
+        self.expires = datetime_now_local() + datetime.timedelta(days=1)
         file_paths = self.get_file_paths_for_page(requested_page)
         data = {}
         for file_path in file_paths:
@@ -92,4 +191,22 @@ class Pagination:
                             if key not in data:
                                 data[key] = []
                             data[key].append(value)
+        self.dump()
         return data
+
+
+def load_pagination(pagination_id: str):
+    """
+    Loads a pagination object from the pagination database if it exists.
+    """
+    with sqlite3.connect(
+        PAGINATION_DATABASE
+    ) as connection, sqlite3.Row as connection.row_factory, connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT [pagination] FROM [pagination] WHERE [paginationId] = ?",
+            pagination_id,
+        )
+        data = cursor.fetchone()
+    if not data:
+        return {"message": f"No pagination found for ID {pagination_id}"}
+    return Pagination(serialized_pagination=data["pagination"])

--- a/temperature_api/api/views.py
+++ b/temperature_api/api/views.py
@@ -18,28 +18,9 @@ def get_available_streams():
 
 
 def get_data_from_stream(pagination, requested_page):
-    """
-    Returns a dictionary of lists containing all the present raw data for the requested stream
-     between the start and end datetimes, inclusive.
-    """
 
     # TODO: get the requested page from the pagination object, or if no page is given, return the first page.
-    file_paths = pagination.get_page_file_paths(requested_page)
-    data = {}
-    for file_path in file_paths:
-        with open(file_path, encoding="utf-8") as file:
-            reader = csv.DictReader(file)
-            for row in reader:
-                if (
-                    start_datetime
-                    <= datetime.fromisoformat(row["Datetime"])
-                    <= end_datetime
-                ):
-                    for key, value in row.items():
-                        if key not in data:
-                            data[key] = []
-                        data[key].append(value)
-    return data
+    return pagination.get_data(requested_page)
 
 
 @api.route("/streams", methods=["GET", "POST"])
@@ -65,6 +46,11 @@ def streams():
         return jsonify(get_available_streams())
 
     data = request.get_json()
+
+    pagination_id = data.get("paginationId")
+    if pagination_id is not None:
+        return load_pagination(pagination_id).get_data()
+
     stream = data.get("stream")
     if stream is None:
         return abort(Response("Missing key: stream", 400))


### PR DESCRIPTION
Pagination is linked to the files in the stream folder.
The number of rows is limited, but as a minimum as files may contain more lines than that minimum.
Pagination objects are stored as TEXT in an sqlite3 database.
Pagination objects can be requested from the /streams endpoint via the POST request and are then retrieved from the database.
A local datetime object can now be calculated and is used as the default datetime calculation in the application.